### PR TITLE
Update pythia6 download location, previous unavailable

### DIFF
--- a/scripts/install_pythia6.sh
+++ b/scripts/install_pythia6.sh
@@ -6,7 +6,7 @@ then
   if [ ! -e pythia6.tar.gz ];
   then
     echo "*** Downloading pythia6 sources ***"
-    download_file ftp://root.cern.ch/root/pythia6.tar.gz
+    download_file https://root.cern.ch/download/pythia6.tar.gz
     echo "*** Downloading $PYTHIA6_LOCATION/$PYTHIA6VERSION.f.gz ***"
     download_file $PYTHIA6_LOCATION/$PYTHIA6VERSION.f.gz
   fi

--- a/scripts/package_versions.sh
+++ b/scripts/package_versions.sh
@@ -16,8 +16,6 @@ export ICUVERSION=icu4c-53_1
 export BOOST_LOCATION="http://sourceforge.net/projects/boost/files/boost/1.59.0/"
 export BOOSTVERSION=boost_1_59_0
 
-#export PYTHIA6_LOCATION="ftp://root.cern.ch/root/"
-#export PYTHIA6VERSION=pythia6
 export PYTHIA6_LOCATION="http://www.hepforge.org/archive/pythia6"
 export PYTHIA6VERSION=pythia-6.4.28
 


### PR DESCRIPTION
As of yesterday the ftp server previously used to download pythia6.tar.gz seems unavailable. As it may not be available for some time I propose updating the location.