### PR TITLE
Update xrootd version to fix Fedora 22/23 seg faults

### DIFF
--- a/scripts/package_versions.sh
+++ b/scripts/package_versions.sh
@@ -48,7 +48,7 @@ else
   export ROOTVERSION=v5-34-34
 fi
 
-export XROOTDVERSION=4.1.1
+export XROOTDVERSION=4.3.0
 
 export PLUTO_LOCATION="http://web-docs.gsi.de/%7Ehadeshyp/pluto/v5.37/"
 export PLUTOVERSION=pluto_v5.37


### PR DESCRIPTION
https://github.com/xrootd/xrootd/issues/313 is affecting the version used to by FairSoft, causing consistent segmentation faults at least on Fedora 23 and probably 22.

The recent xrootd release of 4.3.0 fixed this issue and some related ones by including the change https://github.com/xrootd/xrootd/pull/321.

If the new version causes any issues (so far everything works here), we could apply just the [patch](https://patch-diff.githubusercontent.com/raw/xrootd/xrootd/pull/321.patch) fixing the issue during the installation instead, but using the new version is probably the simplest solution in the long run.