### PR TITLE
Update xerces-c version. Previous has become unavailable (again)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,8 +71,8 @@ transport/geant4.10.01/
 transport/geant4.10.01.p02
 transport/geant4_vmc/
 transport/vgm/
-basics/xerces-c-3.1.2.tar.gz
-basics/xerces-c-3.1.2
+basics/xerces-c-3.1.4.tar.gz
+basics/xerces-c-3.1.4
 basics/xercesc
 basics/Mesa-7.10.3/
 basics/MesaLib-7.10.3.tar.bz2

--- a/scripts/package_versions.sh
+++ b/scripts/package_versions.sh
@@ -25,8 +25,9 @@ export HEPMCVERSION=2.06.09
 export PYTHIA8_LOCATION="http://home.thep.lu.se/~torbjorn/pythia8/"
 export PYTHIA8VERSION=pythia8212
 
+# Old versions available at: https://archive.apache.org/dist/xerces/c/3/sources/
 export XERCESC_LOCATION="http://mirror.serversupportforum.de/apache/xerces/c/3/sources/"
-export XERCESCVERSION=3.1.3
+export XERCESCVERSION=3.1.4
 
 export MESA_LOCATION="ftp://ftp.freedesktop.org/pub/mesa/older-versions/7.x/7.10.3/"
 export MESAVERSION=MesaLib-7.10.3


### PR DESCRIPTION
Hi Thomas,

xerces-c has seen another [bug-fix](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=10510&version=12336069) release, invalidating the old link.

Assuming we'll follow the upstream, I've bumped the version and updated the .gitignore (which we forgot last time).

If not we can switch to the archived version.

All the best,

Oliver