### PR TITLE
Update zeromq location, version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,8 +19,8 @@ basics/gtest-1.7.0.zip
 basics/gtest-1.7.0/
 basics/libsodium
 basics/zeromq
-basics/zeromq-4.1.3.tar.gz
-basics/zeromq-4.1.3/
+basics/zeromq-4.1.5.tar.gz
+basics/zeromq-4.1.5/
 generators/HepMC
 generators/HepMC-2.06.09.tar.gz
 generators/HepMC-2.06.09/

--- a/scripts/install_zeromq.sh
+++ b/scripts/install_zeromq.sh
@@ -6,7 +6,7 @@ then
   if [ ! -e zeromq-$ZEROMQVERSION.tar.gz ];
   then
     echo "*** Downloading zeromq sources ***"
-    download_file $ZEROMQ_LOCATION/zeromq-$ZEROMQVERSION.tar.gz
+    download_file $ZEROMQ_LOCATION/v$ZEROMQVERSION/zeromq-$ZEROMQVERSION.tar.gz
   fi
   untar zeromq zeromq-$ZEROMQVERSION.tar.gz
   if [ -d zeromq-$ZEROMQDIR ];

--- a/scripts/package_versions.sh
+++ b/scripts/package_versions.sh
@@ -68,9 +68,9 @@ export MILLEPEDE_VERSION=V04-03-01
 export SODIUM_LOCATION="https://github.com/jedisct1/libsodium"
 export SODIUMBRANCH=1.0.3
 
-export ZEROMQ_LOCATION="http://download.zeromq.org/"
-export ZEROMQVERSION=4.1.3
-export ZEROMQDIR=4.1.3
+export ZEROMQ_LOCATION="https://github.com/zeromq/zeromq4-1/releases/download/"
+export ZEROMQVERSION=4.1.5
+export ZEROMQDIR=4.1.5
 
 export PROTOBUF_LOCATION="https://github.com/google/protobuf/releases/download/v2.6.1"
 export PROTOBUF_VERSION=protobuf-2.6.1


### PR DESCRIPTION
Hi Thomas,

The next package that has moved after an update is zeromq.

The download has moved from `http://download.zeromq.org/zeromq-$ZEROMQVERSION.tar.gz` to `http://download.zeromq.org/zeromq_$ZEROMQVERSION/zeromq-$ZEROMQVERSION.tar.gz` for old versions.

The current version (4.1.5, our version is 4.1.3) however can now be found at:
`https://github.com/zeromq/zeromq4-1/releases/download/v$ZEROMQVERSION/zeromq-$ZEROMQVERSION.tar.gz`.

The release notes can be found here: https://raw.githubusercontent.com/zeromq/zeromq4-1/master/NEWS .

This update fixes several issues, including build issues with GCC 6 (which is included in Fedora 24, Arch Linux, next Ubuntu(?)). I have done no extensive testing, but with the new zeromq version FairSoft build fine*.

As usual, if you prefer not to upgrade 0MQ, I can update the fix for the new location only, and see whether I can backport the fix for the GCC 6 issues only.

Cheers,

Oliver

*There is also an issue with the Root version in FairSoft. I'll open a separate pull request for that.


