### PR TITLE
Fix use of non-standard c++ in root for gcc 6

### DIFF
--- a/scripts/install_root6.sh
+++ b/scripts/install_root6.sh
@@ -100,6 +100,11 @@ then
     mypatch ../root6_00_find_xrootd.patch
   fi
 
+  # needed to compile root6 with gcc 6
+  if [ "$build_root6" = "yes" ]; then
+    mypatch ../root6-Replace-0x1p-61-GNU-or-C-1z-with-pow-2-61.patch
+  fi
+
   # add python command history to ROOT.py
   mypatch ../root_pythonhistory.patch
 

--- a/tools/root6-Replace-0x1p-61-GNU-or-C-1z-with-pow-2-61.patch
+++ b/tools/root6-Replace-0x1p-61-GNU-or-C-1z-with-pow-2-61.patch
@@ -1,0 +1,21 @@
+--- math/mathcore/src/mixmax.h
++++ math/mathcore/src/mixmax.h
+@@ -33,7 +33,7 @@
+
+ #include <stdio.h>
+ #include <stdint.h>
+-
++#include <math.h>
+
+ #ifdef __cplusplus
+ extern "C" {
+@@ -129,7 +129,7 @@ void branch_inplace( rng_state_t* Xin, myID_t* ID ); // almost the same as apply
+ #define MOD_REM(k) ((k) % MERSBASE )  // latest Intel CPU is supposed to do this in one CPU cycle, but on my machines it seems to be 20% slower than the best tricks
+ #define MOD_MERSENNE(k) MOD_PAYNE(k)
+
+-#define INV_MERSBASE (0x1p-61)
++#define INV_MERSBASE pow(2, -61)
+
+
+ // the charpoly is irreducible for the combinations of N and SPECIAL and has maximal period for N=508, 256, half period for 1260, and 1/12 period for 3150
+


### PR DESCRIPTION
Hi Thomas,

[A bug in our ROOT version](https://sft.its.cern.ch/jira/browse/ROOT-8094) prevents it being built by GCC 6 because of use of non-standard C++ features.

A simple patch fixes that (from the ROOT Jira). Alternatively the bug has been fixed in ROOT 6.06 and the master branch of root, but as we are using 6.05/03 that could include many other changes.

But maybe we should consider upgrading to ROOT 6.06 soon anyway, as that's the current production release.

Cheers,

Oliver