### PR TITLE
Update master to lxplus commit

### DIFF
--- a/tools/root_pythonhistory.patch
+++ b/tools/root_pythonhistory.patch
@@ -1,5 +1,5 @@
---- root/build_for_fair/lib/root/ROOT.py	2015-11-27 18:33:24.000000000 +0100
-+++ /media/ShipSoft/FairShip/../FairSoftInst/lib/root/ROOT.py	2015-12-10 10:04:51.430022701 +0100
+--- root/build_for_fair/lib/root/ROOT.py
++++ root/build_for_fair/lib/root/ROOT.py
 @@ -83,6 +83,12 @@
  
     readline.parse_and_bind( 'tab: complete' )


### PR DESCRIPTION
This allows migrating the default lxplus ShipSoft to master,
so that a second dev lxplus installation can be used for testing 
potentially braking changes.