### PR TITLE
Fix pythonhistory patch

### DIFF
--- a/scripts/install_root6.sh
+++ b/scripts/install_root6.sh
@@ -105,9 +105,6 @@ then
     mypatch ../root6-Replace-0x1p-61-GNU-or-C-1z-with-pow-2-61.patch
   fi
 
-  # add python command history to ROOT.py
-  mypatch ../root_pythonhistory.patch
-
   if [ "$build_root6" = "no" ]; then
     mypatch ../root5_34_find_xrootd.patch
   fi
@@ -116,6 +113,10 @@ then
 
   $MAKE_command -j$number_of_processes
   echo "make finished" 
+
+  # add python command history to ROOT.py
+  mypatch ../../root_pythonhistory.patch
+
   cd $SIMPATH/tools/root/etc/vmc
 
   if [ "$arch" = "linuxx8664icc" ];
@@ -170,8 +171,6 @@ then
      echo "libVc.a not found in lib dirctory "
    fi
    #####################################
-
-
 
   export PATH=${install_prefix}/bin:${PATH}
 

--- a/tools/root_pythonhistory.patch
+++ b/tools/root_pythonhistory.patch
@@ -1,5 +1,5 @@
---- root/build_for_fair/lib/root/ROOT.py
-+++ root/build_for_fair/lib/root/ROOT.py
+--- lib/root/ROOT.py
++++ lib/root/ROOT.py
 @@ -83,6 +83,12 @@
  
     readline.parse_and_bind( 'tab: complete' )


### PR DESCRIPTION
The root_pythonhistory.patch has been failing for a long time now, but was mostly skipped by everyone using it. However the skipping is interactive, so it breaks e.g. docker setup scripts etc..

The issue is that the file that needs to be patched is created after the patch is being applied (and the path is incorrect).

I'm not sure whether the patch is still necessary, but it now applies correctly.

