### PR TITLE
Fix problem introduced by ABI patch

### DIFF
--- a/scripts/install_root.sh
+++ b/scripts/install_root.sh
@@ -96,8 +96,15 @@ then
     mypatch ../root6_00_find_xrootd.patch
     # patches from Fedora, hopefully obsoleted in future by root6.08;
     # needed to compile root6 with gcc 6:
-    mypatch ../root-no-abi-check.patch
-    mypatch ../root-abitags.patch
+    if [ "$compiler" = "gcc" ];
+    then
+      GCC_MAJOR=$(gcc -dumpversion | cut -c 1)
+      if [ "$GCC_MAJOR" -gt 4  ];
+      then
+        mypatch ../root-no-abi-check.patch
+        mypatch ../root-abitags.patch
+      fi
+    fi
   fi
 
   if [ "$build_root6" = "no" ]; then


### PR DESCRIPTION
Make the patches conditional on a gcc major version >  4, (i.e. 5,6).
This fixes issue for GCC versions <5, such as in use on lxplus.

Version logic has been adapted from `install_pluto.sh` and tested with some toy scripts.