### PR TITLE
Gtest version/download location update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,8 @@ basics/gsl
 basics/gsl-1.16.tar.gz
 basics/gsl-1.16/
 basics/gtest
-basics/gtest-1.7.0.zip
-basics/gtest-1.7.0/
+basics/release-1.8.0.zip
+basics/googletest-release-1.8.0/
 basics/libsodium
 basics/zeromq
 basics/zeromq-4.1.5.tar.gz

--- a/scripts/install_gtest.sh
+++ b/scripts/install_gtest.sh
@@ -27,14 +27,15 @@ then
     cd gtest
     mkdir build
     cd build
-    cmake .. -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC
+    cmake .. -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DBUILD_GMOCK=OFF -DBUILD_GTEST=ON
     make
     # fake the installation process
     mkdir -p $install_prefix/lib
+    cd googletest
     cp libgtest.a libgtest_main.a $install_prefix/lib
     if [ ! -d $install_prefix/include/gtest ];then
       mkdir -p $install_prefix/include
-      cp -r ../include/gtest $install_prefix/include
+      cp -r ../../googletest/include/gtest $install_prefix/include
     fi
 
     check_all_libraries  $install_prefix/lib

--- a/scripts/package_versions.sh
+++ b/scripts/package_versions.sh
@@ -5,7 +5,7 @@ export CMAKEVERSION_REQUIRED=cmake-3.1.0
 export CMAKEVERSION=cmake-3.3.2
 
 export GTEST_LOCATION="https://github.com/google/googletest/archive/"
-export GTESTVERSION=release-1.7.0
+export GTESTVERSION=release-1.8.0
 
 export GSL_LOCATION="ftp://ftp.gnu.org/gnu/gsl/"
 export GSLVERSION=gsl-1.16


### PR DESCRIPTION
Hi Thomas,

The location of googletest has changed with a new upstream release a few days ago.
The old version 1.7.0 is not available under the googlecode link anymore.

As googlecode is scheduled to shut down in near future and the official releases are now on github I suggest changing the download links appropriately. The added benefit is that the github links do not change if new versions are released.

The name of the archive and extracted folders needed to be adjusted as well. I'm open to suggestions on how to do this less clumsily.

The upgrade to 1.8.0 contains about 500 commits with various bugfixes and improvements, but no big changes.

All the best,

Oliver