### PR TITLE
Upgrade xroot version to version compatible with GCC >=7.1

### DIFF
--- a/scripts/package_versions.sh
+++ b/scripts/package_versions.sh
@@ -45,7 +45,7 @@ else
   export ROOTVERSION=v5-34-34
 fi
 
-export XROOTDVERSION=4.5.0
+export XROOTDVERSION=4.6.1
 
 export PLUTO_LOCATION="http://web-docs.gsi.de/%7Ehadeshyp/pluto/v5.37/"
 export PLUTOVERSION=pluto_v5.37


### PR DESCRIPTION
GCC 7.1 enables some new default warnings, which break the xroot compilation silently. [The suggested fix by the xroot developers is to simply upgrade to xrootd 4.6.1.](https://github.com/xrootd/xrootd/issues/514)

As far as I can tell xroot 4.6.0 and xroot 4.6.1 are mainly bugfix releases with no backwards incompatible changes. Testing locally I have not encountered any problems either.

GCC 7.1 is used by Fedora 26, OpenSuse Tumbleweed, Arch and probably the next Ubuntu version.
