### PR TITLE
Replaced XercesC URL with official archive URL.

### DIFF
--- a/scripts/package_versions.sh
+++ b/scripts/package_versions.sh
@@ -26,7 +26,7 @@ export PYTHIA8_LOCATION="http://home.thep.lu.se/~torbjorn/pythia8/"
 export PYTHIA8VERSION=pythia8226
 
 # Old versions available at: https://archive.apache.org/dist/xerces/c/3/sources/
-export XERCESC_LOCATION="http://mirror.serversupportforum.de/apache/xerces/c/3/sources/"
+export XERCESC_LOCATION="https://archive.apache.org/dist/xerces/c/3/sources/"
 export XERCESCVERSION=3.1.4
 
 export MESA_LOCATION="ftp://ftp.freedesktop.org/pub/mesa/older-versions/7.x/7.10.3/"


### PR DESCRIPTION
Previous source at "http://mirror.serversupportforum.de" is no longer available.